### PR TITLE
Update eu-west-prod-001 inverter fleet to 1.6.0

### DIFF
--- a/inverter-fleet/fleets/eu-west-prod-001/fleet.yaml
+++ b/inverter-fleet/fleets/eu-west-prod-001/fleet.yaml
@@ -6,10 +6,15 @@ spec:
   selector:
     matchLabels:
       fleet: eu-west-prod-001
+  updatePolicy:
+    failThreshold: 20%
+    batch: 10%
+    maintenanceWindow: "22:00-06:00 Europe/London"
+
   template:
     spec:
       os:
-        image: quay.io/solar-farms/ai-inverter:1.5.0
+        image: quay.io/solar-farms/ai-inverter:1.6.0
 
       systemd:
        matchPatterns:


### PR DESCRIPTION
Update fleet configuration to the latest image

This enhances the AI model for shadow-tracking
 and failure error detection.

An update policy with a fail-threshold of 20% and
batch update size of 10% is added to the fleet. The
maintenance window when updates should start rolling
out is 22:00-06:00 when the sun is already down.
