### PR TITLE
Add FlightCtl Agent bootc images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+QUAYUSER := $(shell echo $(USER))
+
+bootc-fedora:
+	@echo "Building Fedora FlightCtl Agent bootc image..."
+	sudo podman build -t quay.io/${QUAYUSER}/flightctl-agent-fedora:latest -f bootc-agent-images/fedora/Containerfile bootc-agent-images/fedora/
+	sudo podman push quay.io/${QUAYUSER}/flightctl-agent-fedora:latest
+
+bootc-centos:
+	@echo "Building Fedora FlightCtl Agent bootc image..."
+	@echo "Requires RH's VPN"
+	sudo podman build -t quay.io/${QUAYUSER}/flightctl-agent-centos:latest -f bootc-agent-images/centos/Containerfile bootc-agent-images/centos/
+	sudo podman push quay.io/${QUAYUSER}/flightctl-agent-centos:latest
+
+qcow2-bootc:
+	@echo "Building FlightCtl Agent qcow2 image..."
+	mkdir -p output
+	sudo podman run --rm -it --privileged --pull=newer \
+        --security-opt label=type:unconfined_t \
+        -v $(PWD)/output:/output \
+        quay.io/centos-bootc/bootc-image-builder:latest \
+        quay.io/$(QUAYUSER)/flightctl-agent-$(flavor):latest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# flightctl-demo
+# flightctl-demos
+
+This repo contains a series of demos showcasing the edge management capabilities of the flightctl project.
+
+
+## Bootc Agent Images
+
+The `bootc-agent-images` folder contains recipes to build two flavors of bootc images. [Bootc](https://github.com/containers/bootc) provides transactional, in-place operating system images using OCI container images.
+
+This repository provides a recipe for a Fedora ELN based image and a beta RHEL 9.4 based image, both, with the flightctl agent installed in the image. The Fedora recipe provides only the flightctl agent while the RHEL flavor also provides MicroShift as a lightweight Kubernetes runtime.
+
+The config.yaml is pointing at the public instance of the FlightCtl service. However, in order to be able to do the enrollment, some files are needed such as CA and enrollment keypair. Please, ask the team for these files in order to produce an operational device agent against the public service. If you have your own instance of FlightCtl, modify the config.yaml file and add your own files.
+
+In addition to this, both Containerfiles contain a commented section so you can add your SSH public key. Add your ssh key, uncomment and modify that section to enable that build step.
+
+We have created Makefile targets to facilitate the build process. Execute the following command to build and push the image of your choice:
+
+```
+make bootc-fedora QUAYUSER=$yourownquayuser
+````
+
+or
+
+```
+make bootc-centos QUAYUSER=$yourownquayuser
+```
+
+In order to make the deployment of this image easy, you can convert it to QCOW2 format and use it as a raw disk in Libvirt. The following command will create a file called disk.qcow2 within the output folder:
+
+```
+make qcow2-bootc flavor={fedora,centos}
+```

--- a/bootc-agent-images/centos/Containerfile
+++ b/bootc-agent-images/centos/Containerfile
@@ -1,0 +1,21 @@
+FROM registry-proxy.engineering.redhat.com/rh-osbs/rhel9-rhel_bootc:rhel-9.4
+ADD etc etc
+RUN rm -rf /opt && \
+    mkdir -p /opt/cni
+
+RUN dnf install -y microshift flightctl-agent && \
+    systemctl enable microshift.service && \
+    systemctl enable flightctl-agent.service
+
+## Uncomment to add your own ssh key
+# COPY replace_rsa.pub /usr/etc-system/root.keys
+# RUN touch /etc/ssh/sshd_config.d/30-auth-system.conf; \
+#     mkdir -p /usr/etc-system/; \
+#     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf; \
+#     chmod 0600 /usr/etc-system/root.keys
+# VOLUME /var/roothome
+
+## Add your flightctl configuration and certificates
+ADD config.yaml /etc/flightctl/
+ADD ca.crt /etc/flightctl
+ADD client-enrollment.* /etc/flightctl/

--- a/bootc-agent-images/centos/config.yaml
+++ b/bootc-agent-images/centos/config.yaml
@@ -1,0 +1,5 @@
+agent:
+  server: https://api.flightctl.edge-devices.net
+  enrollmentUi: https://ui.flightctl.edge-devices.net
+  fetchSpecInterval: 1m0s
+  statusUpdateInterval: 1m0s

--- a/bootc-agent-images/centos/etc/yum.repos.d/flightctl.repo
+++ b/bootc-agent-images/centos/etc/yum.repos.d/flightctl.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:group_redhat-et:flightctl-dev]
+name=Copr repo for flightctl-dev owned by @redhat-et
+baseurl=https://download.copr.fedorainfracloud.org/results/@redhat-et/flightctl-dev/rhel-9-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@redhat-et/flightctl-dev/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/bootc-agent-images/centos/etc/yum.repos.d/microshift.repo
+++ b/bootc-agent-images/centos/etc/yum.repos.d/microshift.repo
@@ -1,0 +1,11 @@
+[rhocp]
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+
+[fast-datapath]
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/bootc-agent-images/fedora/00-fedora.toml
+++ b/bootc-agent-images/fedora/00-fedora.toml
@@ -1,0 +1,3 @@
+[install]
+root-fs-type = "xfs"
+kargs = "audit=0"

--- a/bootc-agent-images/fedora/Containerfile
+++ b/bootc-agent-images/fedora/Containerfile
@@ -1,0 +1,20 @@
+FROM quay.io/centos-bootc/fedora-bootc:eln
+
+ADD etc etc
+ADD 00-fedora.toml /usr/lib/bootc/install/
+RUN dnf install -y flightctl-agent && \
+    systemctl enable flightctl-agent
+
+## Uncomment to add your own ssh key
+# COPY replace_rsa.pub /usr/etc-system/root.keys
+# RUN touch /etc/ssh/sshd_config.d/30-auth-system.conf; \
+#     mkdir -p /usr/etc-system/; \
+#     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf; \
+#     chmod 0600 /usr/etc-system/root.keys
+# VOLUME /var/roothome
+
+## Add your flightctl configuration and certificates
+ADD config.yaml /etc/flightctl/
+ADD ca.crt /etc/flightctl
+ADD client-enrollment.* /etc/flightctl/
+

--- a/bootc-agent-images/fedora/config.yaml
+++ b/bootc-agent-images/fedora/config.yaml
@@ -1,0 +1,5 @@
+agent:
+  server: https://api.flightctl.edge-devices.net
+  enrollmentUi: https://ui.flightctl.edge-devices.net
+  fetchSpecInterval: 1m0s
+  statusUpdateInterval: 1m0s


### PR DESCRIPTION
I'm not using dnf copr enable due to some failure in the Fedora ELN base image. 

```
STEP 3/6: RUN dnf copr enable -y @redhat-et/flightctl-dev &&     dnf install -y flightctl-agent &&     systemctl enable flightctl-agent
Updating Subscription Management repositories.
Unable to read consumer identity
subscription-manager is operating in container mode.

This system is not registered with an entitlement server. You can use subscription-manager to register.

Enabling a Copr repository. Please note that this repository is not part
of the main distribution, and quality may vary.

The Fedora Project does not exercise any power over the contents of
this repository beyond the rules outlined in the Copr FAQ at
<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
and packages are not held to any quality or security level.

Please do not file bug reports about these packages in Fedora
Bugzilla. In case of problems, contact the owner of this repository.
Error: It wasn't possible to enable this project.
Repository 'fedora-41-x86_64' does not exist in project '@redhat-et/flightctl-dev'.
Available repositories: 'centos-stream-9-x86_64', 'fedora-eln-x86_64', 'fedora-39-aarch64', 'fedora-40-x86_64', 'rhel-9-aarch64', 'fedora-rawhide-x86_64', 'fedora-39-x86_64', 'fedora-rawhide-aarch64', 'fedora-40-aarch64', 'centos-stream-9-aarch64', 'fedora-eln-aarch64', 'rhel-9-x86_64'

If you want to enable a non-default repository, use the following command:
  'dnf copr enable @redhat-et/flightctl-dev <repository>'
But note that the installed repo file will likely need a manual modification.
Error: building at STEP "RUN dnf copr enable -y @redhat-et/flightctl-dev &&     dnf install -y flightctl-agent &&     systemctl enable flightctl-agent": while running runtime: exit status 1
```