### PR TITLE
Add example compliant to new API

### DIFF
--- a/inverter-fleet/fleets/eu-east-prod-001/fleet.yaml
+++ b/inverter-fleet/fleets/eu-east-prod-001/fleet.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1alpha1
+kind: Fleet
+metadata:
+  name: eu-east-prod-001
+spec:
+  selector:
+    matchLabels:
+      fleet: eu-east-prod-001
+  template:
+    spec:
+      os:
+        image: quay.io/solar-farms/ai-inverter:1.5.0
+
+      config:
+        - name: example-server
+          configType: GitConfigProviderSpec
+          gitRef:
+            repository: defaultRepo
+            targetRevision: main
+            path: /inverter-fleet/deployment-manifests/
+
+      containers:
+        matchPatterns:
+          - "*ai-optimizer-model-server*"
+          - "*web-interface*"
+          - "*control-loop*"
+
+      systemd:
+       matchPatterns:
+        - inverter.service
+        - rs485-protocol.service
+


### PR DESCRIPTION
The current example for the `eu-west-prod-001` fleet does not comply with the current API:

- It doesn't specify `configType`
- The properties for the git config are outdated (`repoUrl` instead of `repository`)
- Added a `KubernetesSecretProviderSpec` which is not supported by the API yet.

I created a new resource to avoid conflicts with the existing fleet in the demo environment.
I tested the system using this file, and a valid `templateVersion` was created.