### PR TITLE
Update configs with valid fields

### DIFF
--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -1,6 +1,6 @@
 name: "Build Bootc Agent Bootstrap Images"
 on:
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: '0 */12 * * *'
 

--- a/inverter-fleet/fleets/eu-east-prod-001/fleet.yaml
+++ b/inverter-fleet/fleets/eu-east-prod-001/fleet.yaml
@@ -12,7 +12,7 @@ spec:
         image: quay.io/solar-farms/ai-inverter:1.5.0
 
       config:
-        - name: example-server
+        - name: example-server-a
           configType: GitConfigProviderSpec
           gitRef:
             repository: defaultRepo

--- a/inverter-fleet/fleets/eu-west-prod-001/fleet.yaml
+++ b/inverter-fleet/fleets/eu-west-prod-001/fleet.yaml
@@ -13,16 +13,11 @@ spec:
 
       config:
         - name: model-server
+          configType: GitConfigProviderSpec
           gitRef:
-            repoUrl: https://github.com/flightctl/flightctl-demos.git
-            repoRef: main
+            repository: defaultRepo
             repoPath: /inverter-fleet/deployment-manifests/
             mountPath: /etc/microshift/manifests
-        - name: pull-secret
-          secretRef:
-            name: device-pull-secret
-            namespace: devices
-            mountPath: /etc/crio/pull-secret
 
       containers:
         matchPatterns:

--- a/mlops-pins-fleet/fleet/fleet.yaml
+++ b/mlops-pins-fleet/fleet/fleet.yaml
@@ -13,16 +13,11 @@ spec:
 
       config:
         - name: model-server
+          configType: GitConfigProviderSpec
           gitRef:
-            repoUrl: https://github.com/flightctl/flightctl-demos.git
-            repoRef: main
+            repository: defaultRepo
             repoPath: /inverter-fleet/deployment-manifests/
             mountPath: /etc/microshift/manifests
-        - name: pull-secret
-          secretRef:
-            name: device-pull-secret
-            namespace: devices
-            mountPath: /etc/crio/pull-secret
 
       containers:
         matchPatterns:


### PR DESCRIPTION
Updates the fleet definitions.

1. Changes old `GitConfigProviderSpec` configs using the repository URL to the repository name

2. Removes `KubernetesSecretProviderSpec` configs, which are unsupported and make the fleet status invalid.