### PR TITLE
Make the example valid according to current regexp

### DIFF
--- a/inverter-fleet/fleets/eu-east-prod-001/fleet.yaml
+++ b/inverter-fleet/fleets/eu-east-prod-001/fleet.yaml
@@ -15,15 +15,15 @@ spec:
         - name: example-server-a
           configType: GitConfigProviderSpec
           gitRef:
-            repository: defaultRepo
+            repository: default-repo
             targetRevision: main
             path: /inverter-fleet/deployment-manifests/
 
       containers:
         matchPatterns:
-          - "*ai-optimizer-model-server*"
-          - "*web-interface*"
-          - "*control-loop*"
+          - "ai-optimizer-model-server"
+          - "web-interface"
+          - "control-loop"
 
       systemd:
        matchPatterns:

--- a/inverter-fleet/fleets/eu-west-prod-001/fleet.yaml
+++ b/inverter-fleet/fleets/eu-west-prod-001/fleet.yaml
@@ -15,15 +15,15 @@ spec:
         - name: model-server
           configType: GitConfigProviderSpec
           gitRef:
-            repository: defaultRepo
+            repository: default-repo
             targetRevision: main
             path: /inverter-fleet/deployment-manifests/
 
       containers:
         matchPatterns:
-          - "*ai-optimizer-model-server*"
-          - "*web-interface*"
-          - "*control-loop*"
+          - "ai-optimizer-model-server"
+          - "web-interface"
+          - "control-loop"
 
       systemd:
        matchPatterns:

--- a/mlops-pins-fleet/fleet/fleet.yaml
+++ b/mlops-pins-fleet/fleet/fleet.yaml
@@ -15,15 +15,15 @@ spec:
         - name: model-server
           configType: GitConfigProviderSpec
           gitRef:
-            repository: defaultRepo
+            repository: default-repo
             targetRevision: main
             path: /inverter-fleet/deployment-manifests/
 
       containers:
         matchPatterns:
-          - "*ai-optimizer-model-server*"
-          - "*web-interface*"
-          - "*control-loop*"
+          - "ai-optimizer-model-server"
+          - "web-interface"
+          - "control-loop"
 
       systemd:
        matchPatterns:


### PR DESCRIPTION
The current regexp for `matchPatterns` does not allow for wildcards and shouldn't be accepted by the service.

