### PR TITLE
Add RHEL Image Builder Job to bootc Pipeline

### DIFF
--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '0 */12 * * *'
 
 env:
-  QUAY_ORG: quay.io/flightctl
+  QUAY_ORG: quay.io/${{ github.actor}}
 
 jobs:
   build-and-push-centos:
@@ -50,7 +50,7 @@ jobs:
           file: bootc-agent-images/centos/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/flightctl/flightctl-agent-centos:bootstrap
+          tags: quay.io/${{ github.actor }}/flightctl-agent-centos:bootstrap
 
 
   build-and-push-fedora:
@@ -95,6 +95,58 @@ jobs:
           file: bootc-agent-images/fedora/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/flightctl/flightctl-agent-fedora:bootstrap
+          tags: quay.io/${{ github.actor }}/flightctl-agent-fedora:bootstrap
+
+
+  build-and-push-rhel:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Modify RHEL Containerfile
+        run: |
+          pushd bootc-agent-images/rhel
+          echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
+          sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     mkdir -p \/usr\/etc-system\/;/    mkdir -p \/usr\/etc-system\/;/' \
+                 -e 's/^#     echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/    echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     chmod 0600 \/usr\/etc-system\/root.keys/    chmod 0600 \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# VOLUME \/var\/roothome/VOLUME \/var\/roothome/' Containerfile
+          echo "${{ secrets.CA_CRT }}" > ca.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_CRT }}" > client-enrollment.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_KEY }}" > client-enrollment.key
+          popd
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to registry.redhat.io
+        uses: docker/login-action@v3
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: bootc-agent-images/rhel
+          file: bootc-agent-images/rhel/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ github.actor }}/flightctl-agent-rhel:bootstrap
 
 


### PR DESCRIPTION
For this to work there will need to be a registry.redhat.io account with the same login as quay.io/flightctl so the pipeline can access the RHEL base image.

Adds a job to our build-bootc.yaml to build a RHEL bootc image in the same manner as the CentOS and Fedora agent images.