### PR TITLE
Sign Pipeline Container Images with Cosign

### DIFF
--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -5,7 +5,8 @@ on:
     - cron: '0 */12 * * *'
 
 env:
-  QUAY_ORG: quay.io/${{ github.actor}}
+  REGISTRY: quay.io
+  REPOSITORY: ${{ github.actor }}
 
 jobs:
   build-and-push-centos:
@@ -39,7 +40,7 @@ jobs:
       - name: Login to Quay.io
         uses: docker/login-action@v3
         with:
-          registry: quay.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
@@ -50,7 +51,7 @@ jobs:
           file: bootc-agent-images/centos/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/${{ github.actor }}/flightctl-agent-centos:bootstrap
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-centos:bootstrap
 
 
   build-and-push-fedora:
@@ -84,7 +85,7 @@ jobs:
       - name: Login to Quay.io
         uses: docker/login-action@v3
         with:
-          registry: quay.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
@@ -95,58 +96,6 @@ jobs:
           file: bootc-agent-images/fedora/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/${{ github.actor }}/flightctl-agent-fedora:bootstrap
-
-
-  build-and-push-rhel:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Modify RHEL Containerfile
-        run: |
-          pushd bootc-agent-images/rhel
-          echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
-          sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
-                 -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
-                 -e 's/^#     mkdir -p \/usr\/etc-system\/;/    mkdir -p \/usr\/etc-system\/;/' \
-                 -e 's/^#     echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/    echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
-                 -e 's/^#     chmod 0600 \/usr\/etc-system\/root.keys/    chmod 0600 \/usr\/etc-system\/root.keys/' \
-                 -e 's/^# VOLUME \/var\/roothome/VOLUME \/var\/roothome/' Containerfile
-          echo "${{ secrets.CA_CRT }}" > ca.crt
-          echo "${{ secrets.CLIENT_ENROLLMENT_CRT }}" > client-enrollment.crt
-          echo "${{ secrets.CLIENT_ENROLLMENT_KEY }}" > client-enrollment.key
-          popd
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to registry.redhat.io
-        uses: docker/login-action@v3
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: bootc-agent-images/rhel
-          file: bootc-agent-images/rhel/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: quay.io/${{ github.actor }}/flightctl-agent-rhel:bootstrap
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-fedora:bootstrap
 
 

--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '0 */12 * * *'
 
 env:
-  QUAY_ORG: quay.io/flightctl
+  QUAY_ORG: quay.io/${{ github.actor}}
 
 jobs:
   build-and-push-centos:
@@ -50,7 +50,7 @@ jobs:
           file: bootc-agent-images/centos/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/flightctl/flightctl-agent-centos:bootstrap
+          tags: quay.io/${{ github.actor }}/flightctl-agent-centos:bootstrap
 
 
   build-and-push-fedora:
@@ -95,6 +95,58 @@ jobs:
           file: bootc-agent-images/fedora/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/flightctl/flightctl-agent-fedora:bootstrap
+          tags: quay.io/${{ github.actor }}/flightctl-agent-fedora:bootstrap
+
+
+  build-and-push-rhel:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Modify RHEL Containerfile
+        run: |
+          pushd bootc-agent-images/rhel
+          echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
+          sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     mkdir -p \/usr\/etc-system\/;/    mkdir -p \/usr\/etc-system\/;/' \
+                 -e 's/^#     echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/    echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     chmod 0600 \/usr\/etc-system\/root.keys/    chmod 0600 \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# VOLUME \/var\/roothome/VOLUME \/var\/roothome/' Containerfile
+          echo "${{ secrets.CA_CRT }}" > ca.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_CRT }}" > client-enrollment.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_KEY }}" > client-enrollment.key
+          popd
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to registry.redhat.io
+        uses: docker/login-action@v3
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: bootc-agent-images/rhel
+          file: bootc-agent-images/rhel/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ github.actor }}/flightctl-agent-rhel:bootstrap
 
 

--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -6,11 +6,16 @@ on:
 
 env:
   REGISTRY: quay.io
-  REPOSITORY: ${{ github.actor }}
+  REGISTRY_USER: ${{ github.actor }}
 
 jobs:
   build-and-push-centos:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     steps:
       - name: Checkout
@@ -32,30 +37,53 @@ jobs:
           popd
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
-      - name: Login to Quay.io
+      - name: Login to registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
-      - name: Build and push
+      - name: Build CentOS image
+        uses: docker/build-push-action@v5
+        with:
+          context: bootc-agent-images/centos
+          file: bootc-agent-images/centos/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: localhost:5000/user/flightctl-agent-centos:bootstrap
+
+      - name: Test CentOS image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: localhost:5000/user/flightctl-agent-centos:bootstrap
+          run: |
+            rpm -qa | grep flightctl-agent
+            exit $?
+
+      - name: Push CentOS image
         uses: docker/build-push-action@v2
         with:
           context: bootc-agent-images/centos
           file: bootc-agent-images/centos/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-centos:bootstrap
-
+          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-centos:bootstrap
 
   build-and-push-fedora:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     steps:
       - name: Checkout
@@ -77,25 +105,44 @@ jobs:
           popd
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
-      - name: Login to Quay.io
+      - name: Login to registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
-      - name: Build and push
+      - name: Build Fedora image
+        uses: docker/build-push-action@v5
+        with:
+          context: bootc-agent-images/fedora
+          file: bootc-agent-images/fedora/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: localhost:5000/user/flightctl-agent-fedora:bootstrap
+
+      - name: Test Fedora image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: localhost:5000/user/flightctl-agent-fedora:bootstrap
+          run: |
+            rpm -qa | grep flightctl-agent
+            exit $?
+
+      - name: Push Fedora image
         uses: docker/build-push-action@v2
         with:
           context: bootc-agent-images/fedora
           file: bootc-agent-images/fedora/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-fedora:bootstrap
+          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-fedora:bootstrap
 
 

--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -17,6 +17,11 @@ jobs:
         ports:
           - 5000:5000
 
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -70,12 +75,22 @@ jobs:
 
       - name: Push CentOS image
         uses: docker/build-push-action@v2
+        id: push
         with:
           context: bootc-agent-images/centos
           file: bootc-agent-images/centos/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-centos:bootstrap
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign CentOS
+        run: |
+          cosign sign \
+            --yes \
+            ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-centos@${{ steps.push.outputs.digest }}
 
   build-and-push-fedora:
     runs-on: ubuntu-latest
@@ -84,6 +99,11 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -137,6 +157,7 @@ jobs:
             exit $?
 
       - name: Push Fedora image
+        id: push
         uses: docker/build-push-action@v2
         with:
           context: bootc-agent-images/fedora
@@ -145,4 +166,11 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-fedora:bootstrap
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
 
+      - name: Sign Fedora
+        run: |
+          cosign sign \
+            --yes \
+            ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-fedora@${{ steps.push.outputs.digest }}

--- a/.github/workflows/build-rhel-bootc.yaml
+++ b/.github/workflows/build-rhel-bootc.yaml
@@ -1,0 +1,50 @@
+name: "Build RHEL Bootc Agent Bootstrap Image" 
+on:
+  workflow_dispatch
+env:
+  REGISTRY: quay.io
+  REPOSITORY: ${{ github.actor }}
+
+jobs:
+  build-and-push-rhel:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Modify RHEL Containerfile
+        run: |
+          pushd bootc-agent-images/rhel
+          echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
+          sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     mkdir -p \/usr\/etc-system\/;/    mkdir -p \/usr\/etc-system\/;/' \
+                 -e 's/^#     echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/    echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     chmod 0600 \/usr\/etc-system\/root.keys/    chmod 0600 \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# VOLUME \/var\/roothome/VOLUME \/var\/roothome/' Containerfile
+          echo "${{ secrets.CA_CRT }}" > ca.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_CRT }}" > client-enrollment.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_KEY }}" > client-enrollment.key
+          popd
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to registry.redhat.io
+        uses: docker/login-action@v3
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+

--- a/.github/workflows/build-rhel-bootc.yaml
+++ b/.github/workflows/build-rhel-bootc.yaml
@@ -15,6 +15,11 @@ jobs:
         ports:
           - 5000:5000
 
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +62,6 @@ jobs:
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
       - name: Build RHEL image
-        id: build
         uses: docker/build-push-action@v5
         with:
           context: bootc-agent-images/rhel
@@ -76,9 +80,21 @@ jobs:
 
       - name: Push RHEL image
         uses: docker/build-push-action@v2
+        id: push
         with:
           context: bootc-agent-images/rhel
           file: bootc-agent-images/rhel/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-rhel:bootstrap
+    
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+        # signs with ID https://github.com/${{ github.actor }}/flightctl-demos/.github/workflows/build-bootc.yaml@refs/heads/${{ github.branch }}
+        # and issuer https://token.actions.githubusercontent.com
+      - name: Sign RHEL
+        run: |
+          cosign sign \
+            --yes \
+            ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-rhel@${{ steps.push.outputs.digest }}

--- a/.github/workflows/build-rhel-bootc.yaml
+++ b/.github/workflows/build-rhel-bootc.yaml
@@ -3,11 +3,17 @@ on:
   workflow_dispatch
 env:
   REGISTRY: quay.io
-  REPOSITORY: ${{ github.actor }}
+  REGISTRY_USER: ${{ github.actor }}
 
 jobs:
   build-and-push-rhel:
     runs-on: ubuntu-latest
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     steps:
       - name: Checkout
@@ -29,10 +35,12 @@ jobs:
           popd
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Login to registry.redhat.io
         uses: docker/login-action@v3
@@ -41,10 +49,36 @@ jobs:
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
-      - name: Login to Quay.io
+      - name: Login to registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
+      - name: Build RHEL image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: bootc-agent-images/rhel
+          file: bootc-agent-images/rhel/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: localhost:5000/user/flightctl-agent-rhel:bootstrap
+
+      - name: Test RHEL image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: localhost:5000/user/flightctl-agent-rhel:bootstrap
+          run: |
+            rpm -qa | grep flightctl-agent
+            exit $?
+
+      - name: Push RHEL image
+        uses: docker/build-push-action@v2
+        with:
+          context: bootc-agent-images/rhel
+          file: bootc-agent-images/rhel/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/flightctl-agent-rhel:bootstrap


### PR DESCRIPTION
Signs bootc container images pushed by GitHub Actions pipeline using GitHub OIDC tokens with cosign.

Will only sign the image if the container checks in the previous stage were successful. Those checks don't have anything to do with security, but I assume that we don't want to be signing images that aren't functional. This dependency can be removed by excluding verify-FLAVOR from jobs.sign-FLAVOR.needs.