### PR TITLE
Fix CI and add RHEL periodic pipeline

### DIFF
--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -1,12 +1,12 @@
 name: "Build Bootc Agent Bootstrap Images"
 on:
-  pull_request_target:
+  pull_request:
   schedule:
     - cron: '0 */12 * * *'
 
 env:
   REGISTRY: quay.io
-  REPOSITORY: ${{ github.actor }}
+  REPOSITORY: flightctl
 
 jobs:
   build-and-push-centos:
@@ -98,4 +98,55 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-fedora:bootstrap
 
+
+  build-and-push-rhel:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Modify RHEL Containerfile
+        run: |
+          pushd bootc-agent-images/rhel
+          echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
+          sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     mkdir -p \/usr\/etc-system\/;/    mkdir -p \/usr\/etc-system\/;/' \
+                 -e 's/^#     echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/    echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
+                 -e 's/^#     chmod 0600 \/usr\/etc-system\/root.keys/    chmod 0600 \/usr\/etc-system\/root.keys/' \
+                 -e 's/^# VOLUME \/var\/roothome/VOLUME \/var\/roothome/' Containerfile
+          echo "${{ secrets.CA_CRT }}" > ca.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_CRT }}" > client-enrollment.crt
+          echo "${{ secrets.CLIENT_ENROLLMENT_KEY }}" > client-enrollment.key
+          popd
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Login to Red Hat Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USERNAME }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: bootc-agent-images/rhel
+          file: bootc-agent-images/rhel/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-rhel:bootstrap
 


### PR DESCRIPTION
Let's have pipelines for the three OS flavors (Centos, Fedora and RHEL) in a periodic manner. And keep the experimental manual pipeline using a separate tag.