### PR TITLE
verify software artifacts before pushing to registry

### DIFF
--- a/.github/workflow-scripts/verify-flightctl-agent.sh
+++ b/.github/workflow-scripts/verify-flightctl-agent.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rpm -qa | grep flightctl-agent
+exit $?

--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -9,16 +9,20 @@ env:
   REPOSITORY: flightctl
 
 jobs:
-  build-and-push-centos:
+  build-and-push:
     runs-on: ubuntu-latest
+  
+    strategy:
+      matrix:
+        flavor: [centos, fedora, rhel]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Modify CentOS Containerfile
+      - name: Modify Containerfile
         run: |
-          pushd bootc-agent-images/centos
+          pushd bootc-agent-images/${{ matrix.flavor }}
           echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
           sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
                  -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
@@ -32,121 +36,48 @@ jobs:
           popd
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: bootc-agent-images/centos
-          file: bootc-agent-images/centos/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-centos:bootstrap
-
-
-  build-and-push-fedora:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Modify Fedora Containerfile
-        run: |
-          pushd bootc-agent-images/fedora
-          echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
-          sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
-                 -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
-                 -e 's/^#     mkdir -p \/usr\/etc-system\/;/    mkdir -p \/usr\/etc-system\/;/' \
-                 -e 's/^#     echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/    echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
-                 -e 's/^#     chmod 0600 \/usr\/etc-system\/root.keys/    chmod 0600 \/usr\/etc-system\/root.keys/' \
-                 -e 's/^# VOLUME \/var\/roothome/VOLUME \/var\/roothome/' Containerfile
-          echo "${{ secrets.CA_CRT }}" > ca.crt
-          echo "${{ secrets.CLIENT_ENROLLMENT_CRT }}" > client-enrollment.crt
-          echo "${{ secrets.CLIENT_ENROLLMENT_KEY }}" > client-enrollment.key
-          popd
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: bootc-agent-images/fedora
-          file: bootc-agent-images/fedora/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-fedora:bootstrap
-
-
-  build-and-push-rhel:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Modify RHEL Containerfile
-        run: |
-          pushd bootc-agent-images/rhel
-          echo "${{ secrets.FLIGHTCTL_RSA_PUB }}" > flightctl_rsa.pub
-          sed -i -e 's/^# COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/COPY flightctl_rsa.pub \/usr\/etc-system\/root.keys/' \
-                 -e 's/^# RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/RUN touch \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
-                 -e 's/^#     mkdir -p \/usr\/etc-system\/;/    mkdir -p \/usr\/etc-system\/;/' \
-                 -e 's/^#     echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/    echo '\''AuthorizedKeysFile \/usr\/etc-system\/%u.keys'\'' >> \/etc\/ssh\/sshd_config.d\/30-auth-system.conf;/' \
-                 -e 's/^#     chmod 0600 \/usr\/etc-system\/root.keys/    chmod 0600 \/usr\/etc-system\/root.keys/' \
-                 -e 's/^# VOLUME \/var\/roothome/VOLUME \/var\/roothome/' Containerfile
-          echo "${{ secrets.CA_CRT }}" > ca.crt
-          echo "${{ secrets.CLIENT_ENROLLMENT_CRT }}" > client-enrollment.crt
-          echo "${{ secrets.CLIENT_ENROLLMENT_KEY }}" > client-enrollment.key
-          popd
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Login to Red Hat Registry
+      - name: Login to registry.redhat.io (for RHEL image)
+        if: ${{ matrix.flavor }} == 'rhel'
         uses: docker/login-action@v3
         with:
           registry: registry.redhat.io
           username: ${{ secrets.RH_REGISTRY_USERNAME }}
           password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Quay.io
+      - name: Login to registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
-      - name: Build and push
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: bootc-agent-images/${{ matrix.flavor }}
+          file: bootc-agent-images/${{ matrix.flavor }}/Containerfile
+          load: true
+          tags: user/flightctl-agent:test
+
+      - name: Test image
+        run: |
+          ID=$(docker create ${{ steps.build.outputs.imageid }} /verify-flightctl-agent.sh)
+          docker cp .github/workflow-scripts/verify-flightctl-agent.sh $ID:/
+          docker start $ID
+          exit $(docker inspect $ID --format='{{.State.ExitCode}}')
+
+      - name: Push image
         uses: docker/build-push-action@v2
         with:
-          context: bootc-agent-images/rhel
-          file: bootc-agent-images/rhel/Containerfile
+          context: bootc-agent-images/${{ matrix.flavor }}
+          file: bootc-agent-images/${{ matrix.flavor }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-rhel:bootstrap
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-${{ matrix.flavor }}:bootstrap
 

--- a/.github/workflows/build-rhel-bootc.yaml
+++ b/.github/workflows/build-rhel-bootc.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch
 env:
   REGISTRY: quay.io
-  REPOSITORY: ${{ github.actor }}
+  REPOSITORY: flightctl
 
 jobs:
   build-and-push-rhel:
@@ -29,22 +29,47 @@ jobs:
           popd
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to registry.redhat.io
         uses: docker/login-action@v3
         with:
           registry: registry.redhat.io
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+          username: ${{ secrets.RH_REGISTRY_USERNAME }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-      - name: Login to Quay.io
+      - name: Login to registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
 
+      - name: Build RHEL image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: bootc-agent-images/rhel
+          file: bootc-agent-images/rhel/Containerfile
+          load: true
+          tags: user/flightctl-agent:testing
+
+      - name: Test RHEL image
+        run: |
+          ID=$(docker create ${{ steps.build.outputs.imageid }} /verify-flightctl-agent.sh)
+          docker cp .github/workflow-scripts/verify-flightctl-agent.sh $ID:/
+          docker start -a $ID
+          docker inspect $ID
+          exit $(docker inspect $ID --format='{{.State.ExitCode}}')
+
+      - name: Push RHEL image
+        uses: docker/build-push-action@v2
+        with:
+          context: bootc-agent-images/rhel
+          file: bootc-agent-images/rhel/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-rhel:bootstrap-experimental

--- a/bootc-agent-images/fedora/Containerfile
+++ b/bootc-agent-images/fedora/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos-bootc/fedora-bootc:eln
+FROM quay.io/fedora/fedora-bootc:40
 
 ADD etc etc
 ADD 00-fedora.toml /usr/lib/bootc/install/


### PR DESCRIPTION
Run script inside container image to verify that flightctl-agent has been installed before pushing the container to the registry.

This is the same as PR #18, but since RHEL requires credentials to even acquire the base image and build, trying to make the pipeline robust to the case where a PR is opened from a fork requires more logic than it's worth IMO, so I made a new branch inside the repo and copied all the files over instead.