### PR TITLE
Sign workflow containers before pushing to registry

### DIFF
--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -12,6 +12,11 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
   
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     strategy:
       matrix:
         flavor: [centos, fedora, rhel]
@@ -73,6 +78,7 @@ jobs:
           exit $(docker inspect $ID --format='{{.State.ExitCode}}')
 
       - name: Push image
+        id: push
         uses: docker/build-push-action@v2
         with:
           context: bootc-agent-images/${{ matrix.flavor }}
@@ -81,3 +87,11 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-${{ matrix.flavor }}:bootstrap
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign image
+        run: |
+          cosign sign \
+            --yes \
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-${{ matrix.flavor }}@${{ steps.push.outputs.digest }}

--- a/.github/workflows/build-rhel-bootc.yaml
+++ b/.github/workflows/build-rhel-bootc.yaml
@@ -9,6 +9,11 @@ jobs:
   build-and-push-rhel:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -66,6 +71,7 @@ jobs:
           exit $(docker inspect $ID --format='{{.State.ExitCode}}')
 
       - name: Push RHEL image
+        id: push
         uses: docker/build-push-action@v2
         with:
           context: bootc-agent-images/rhel
@@ -73,3 +79,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-rhel:bootstrap-experimental
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign image
+        run: |
+          cosign sign \
+            --yes \
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-rhel@${{ steps.push.outputs.digest }}


### PR DESCRIPTION
Sign workflow containers with GitHub ID token before pushing to registry.

Redo of PR #19 using flightctl-demos branch.