### PR TITLE
Sign bootc image manifests

### DIFF
--- a/.github/workflow-scripts/buildah-build-and-push-manifest.sh
+++ b/.github/workflow-scripts/buildah-build-and-push-manifest.sh
@@ -19,4 +19,6 @@ for FILE in *; do
 		--arch $ARCH
 done
 
-buildah manifest push --all bootc-images docker://$BUILDAH_URL
+buildah manifest push \
+	--all bootc-images docker://$BUILDAH_URL \
+	--digestfile digest

--- a/.github/workflows/build-bootc.yaml
+++ b/.github/workflows/build-bootc.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-and-push-bootstrap-images:
     runs-on: ubuntu-latest
-  
+
     permissions:
       contents: read
       packages: write
@@ -96,12 +96,16 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0
 
-      - name: Sign image
+      - name: Sign images
         run: |
+          cosign login \
+            -u "${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}" \
+            -p "${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}" \
+            quay.io
+
           cosign sign \
             --yes \
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-${{ matrix.flavor }}@${{ steps.push.outputs.digest }}
-
 
   build-bootc-images:
     needs: build-and-push-bootstrap-images
@@ -156,6 +160,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -182,6 +191,7 @@ jobs:
           merge-multiple: true
         
       - name: Build and push disk images
+        id: build-and-push
         run: |
           cp .github/workflow-scripts/buildah-build-and-push-manifest.sh bootc-images
           URL=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-${{ matrix.flavor }}
@@ -194,3 +204,21 @@ jobs:
             -e "BUILDAH_URL=$URL:bootc" \
             quay.io/buildah/stable:v1.36.0 \
               /bootc-images/buildah-build-and-push-manifest.sh
+          
+          DIGEST=$(cat bootc-images/digest)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+
+      - name: Sign images
+        run: |
+          cosign login \
+            -u "${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}" \
+            -p "${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}" \
+            quay.io
+          
+          cosign sign \
+            --yes \
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/flightctl-agent-${{ matrix.flavor }}@${{ steps.build-and-push.outputs.digest }}

--- a/fetch-artifact.sh
+++ b/fetch-artifact.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
 # Args:
-# $1: container registry url
+# $1: container url
 # $2: platform
 # $3: output path
+
+if [ $# -ne 3 ]; then
+	echo "$0 <container url> <platform> <output path>"
+	exit 1
+fi
 
 sha=$(oras manifest fetch $1 --platform $2 | jq '.layers.[0].digest' -r)
 oras blob fetch $1@$sha --output $3


### PR DESCRIPTION
Since the bootc images are going to be what the end-user actually use, we should sign those too