### PR TITLE
NO-ISSUE: add make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,6 @@ raw-bootc:
 		--type raw \
 		--config /config.json \
 		quay.io/$(QUAYUSER)/$(image):latest
+
+clean:
+    - rm -f -r output


### PR DESCRIPTION
This PR adds `make clean` to ensure that builds are not stale.