### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ raw-bootc:
 		quay.io/$(QUAYUSER)/$(image):latest
 
 clean:
-    - rm -f -r output
+	- rm -f -r output


### PR DESCRIPTION
Fixing error 
`Makefile:54: *** missing separator.  Stop.`
Replacing spaces with tab