### PR TITLE
Dont use vars in inputs

### DIFF
--- a/.github/workflows/build-bootc-diskimage.yaml
+++ b/.github/workflows/build-bootc-diskimage.yaml
@@ -20,7 +20,7 @@ on:
         description: 'OCI organisation to push image to.'
         type: string
         required: true
-        default: '${{ github.repository_owner }}'
+        default: 'flightctl-demos'
   workflow_call:
     inputs:
       demo:
@@ -40,7 +40,7 @@ on:
         description: 'OCI organisation to push image to.'
         type: string
         required: true
-        default: '${{ github.repository_owner }}'
+        default: 'flightctl-demos'
     secrets:
       OCI_REGISTRY_USERNAME:
         required: true

--- a/.github/workflows/build-bootc-image.yaml
+++ b/.github/workflows/build-bootc-image.yaml
@@ -20,7 +20,7 @@ on:
         description: 'OCI organisation to push image to.'
         type: string
         required: true
-        default: '${{ github.repository_owner }}'
+        default: 'flightctl-demos'
   workflow_call:
     inputs:
       demo:
@@ -40,7 +40,7 @@ on:
         description: 'OCI organisation to push image to.'
         type: string
         required: true
-        default: '${{ github.repository_owner }}'
+        default: 'flightctl-demos'
     secrets:
       OCI_REGISTRY_USERNAME:
         required: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the default organization setting for automated image workflows to always use "flightctl-demos," ensuring a consistent deployment configuration regardless of invocation method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->