### PR TITLE
feat: Support single architecture container images

### DIFF
--- a/.github/workflows/build-bootc-diskimage.yaml
+++ b/.github/workflows/build-bootc-diskimage.yaml
@@ -50,7 +50,27 @@ on:
         required: true
 
 jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v4
+
+      - name: Verify at least one Containerfile exists
+        run: |
+          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          for arch in amd64 arm64; do
+            if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
+              echo "Found Containerfile for ${arch}"
+              exit 0
+            fi
+          done
+          echo "Error: No Containerfile found for any architecture in ${DEMO_DIR}/bootc/"
+          exit 1
+
   build-bootc-disk-images:
+    needs: [preflight]
+
     strategy:
       matrix:
         runner: ["ubuntu-24.04","ubuntu-24.04-arm"]
@@ -67,13 +87,27 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
 
+      - name: Check if Containerfile exists for this architecture
+        id: check-containerfile
+        run: |
+          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          if [ -f "${DEMO_DIR}/bootc/Containerfile.${{ env.ARCH }}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "No Containerfile found for ${{ env.ARCH }}, skipping disk image build"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup Podman 5
+        if: steps.check-containerfile.outputs.exists == 'true'
         uses: ./.github/actions/setup-podman5
 
       - name: Log in to OCI registry
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: podman login -u '${{ secrets.OCI_REGISTRY_USERNAME }}' -p '${{ secrets.OCI_REGISTRY_PASSWORD }}' ${{ inputs.oci-registry }}
 
       - name: Set env vars
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           echo "OCI_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}" >> $GITHUB_ENV
           echo "OCI_IMAGE_TAG=${GITHUB_SHA::8}-${{ env.ARCH }}" >> $GITHUB_ENV
@@ -81,6 +115,7 @@ jobs:
           echo "OCI_DISK_IMAGE_TAG=${GITHUB_SHA::8}-${{ env.ARCH }}" >> $GITHUB_ENV
 
       - name: Build disk image
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/output"
 
@@ -105,7 +140,7 @@ jobs:
 
       # Upload all formats except QCoW2 as OCI artifact
       - name: Push disk image to registry as OCI artifact and sign it
-        if: ${{ matrix.format != 'qcow2' }}
+        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format != 'qcow2'
         run: |
           printf '%s' '${{ secrets.SIGNING_KEY_PRIVATE }}' > ./signingkey.private
 
@@ -124,7 +159,7 @@ jobs:
 
       # Upload QCoW2 as "containerdisk" OCI image as expected by KubeVirt
       - name: Create the Containerfile for building the containerdisk image
-        if: ${{ matrix.format == 'qcow2' }}
+        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format == 'qcow2'
         run: |
           cat <<EOF > Containerfile.qcow2
           FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
@@ -136,12 +171,12 @@ jobs:
           EOF
 
       - name: Build the containerdisk image
-        if: ${{ matrix.format == 'qcow2' }}
+        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format == 'qcow2'
         run: |
           podman build -t ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG} -f Containerfile.qcow2 .
 
       - name: Push the containerdisk image to registry as OCI image and sign it
-        if: ${{ matrix.format == 'qcow2' }}
+        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format == 'qcow2'
         run: |
           printf '%s' '${{ secrets.SIGNING_KEY_PRIVATE }}' > ./signingkey.private
           podman push --sign-by-sigstore-private-key ./signingkey.private ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG}
@@ -202,10 +237,28 @@ jobs:
           echo "OCI_DISK_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}/diskimage-${{ matrix.format }}" >> $GITHUB_ENV
           echo "OCI_DISK_IMAGE_TAG=${GITHUB_SHA::8}" >> $GITHUB_ENV
 
+      - name: Detect available architectures
+        id: detect-archs
+        run: |
+          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          ARCHS=""
+          for arch in amd64 arm64; do
+            if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
+              ARCHS="${ARCHS} ${arch}"
+            fi
+          done
+          ARCHS=$(echo "${ARCHS}" | xargs)
+          if [ -z "${ARCHS}" ]; then
+            echo "Error: No Containerfiles found for any architecture"
+            exit 1
+          fi
+          echo "archs=${ARCHS}" >> $GITHUB_OUTPUT
+          echo "Architectures to include in manifest: ${ARCHS}"
+
       - name: Create manifest list
         run: |
           podman manifest create ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG}
-          for arch in amd64 arm64; do
+          for arch in ${{ steps.detect-archs.outputs.archs }}; do
             podman manifest add --all ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG} docker://${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG}-${arch}
           done
 

--- a/.github/workflows/build-bootc-diskimage.yaml
+++ b/.github/workflows/build-bootc-diskimage.yaml
@@ -52,28 +52,44 @@ on:
 jobs:
   preflight:
     runs-on: ubuntu-24.04
+    outputs:
+      runners: ${{ steps.detect-archs.outputs.runners }}
+      archs: ${{ steps.detect-archs.outputs.archs }}
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
 
-      - name: Verify at least one Containerfile exists
+      - name: Detect available architectures
+        id: detect-archs
         run: |
           DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          RUNNERS="[]"
+          ARCHS=""
           for arch in amd64 arm64; do
             if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
-              echo "Found Containerfile for ${arch}"
-              exit 0
+              if [ "${arch}" = "amd64" ]; then
+                RUNNERS=$(echo "${RUNNERS}" | jq -c '. + ["ubuntu-24.04"]')
+              else
+                RUNNERS=$(echo "${RUNNERS}" | jq -c '. + ["ubuntu-24.04-arm"]')
+              fi
+              ARCHS="${ARCHS} ${arch}"
             fi
           done
-          echo "Error: No Containerfile found for any architecture in ${DEMO_DIR}/bootc/"
-          exit 1
+          ARCHS=$(echo "${ARCHS}" | xargs)
+          if [ -z "${ARCHS}" ]; then
+            echo "Error: No Containerfile found for any architecture in ${DEMO_DIR}/bootc/"
+            exit 1
+          fi
+          echo "runners=${RUNNERS}" >> $GITHUB_OUTPUT
+          echo "archs=${ARCHS}" >> $GITHUB_OUTPUT
+          echo "Architectures: ${ARCHS}, Runners: ${RUNNERS}"
 
   build-bootc-disk-images:
     needs: [preflight]
 
     strategy:
       matrix:
-        runner: ["ubuntu-24.04","ubuntu-24.04-arm"]
+        runner: ${{ fromJSON(needs.preflight.outputs.runners) }}
         format: [iso, qcow2, raw]
       max-parallel: 4
       fail-fast: false
@@ -87,27 +103,13 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
 
-      - name: Check if Containerfile exists for this architecture
-        id: check-containerfile
-        run: |
-          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
-          if [ -f "${DEMO_DIR}/bootc/Containerfile.${{ env.ARCH }}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "No Containerfile found for ${{ env.ARCH }}, skipping disk image build"
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Setup Podman 5
-        if: steps.check-containerfile.outputs.exists == 'true'
         uses: ./.github/actions/setup-podman5
 
       - name: Log in to OCI registry
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: podman login -u '${{ secrets.OCI_REGISTRY_USERNAME }}' -p '${{ secrets.OCI_REGISTRY_PASSWORD }}' ${{ inputs.oci-registry }}
 
       - name: Set env vars
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           echo "OCI_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}" >> $GITHUB_ENV
           echo "OCI_IMAGE_TAG=${GITHUB_SHA::8}-${{ env.ARCH }}" >> $GITHUB_ENV
@@ -115,7 +117,6 @@ jobs:
           echo "OCI_DISK_IMAGE_TAG=${GITHUB_SHA::8}-${{ env.ARCH }}" >> $GITHUB_ENV
 
       - name: Build disk image
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/output"
 
@@ -140,7 +141,7 @@ jobs:
 
       # Upload all formats except QCoW2 as OCI artifact
       - name: Push disk image to registry as OCI artifact and sign it
-        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format != 'qcow2'
+        if: ${{ matrix.format != 'qcow2' }}
         run: |
           printf '%s' '${{ secrets.SIGNING_KEY_PRIVATE }}' > ./signingkey.private
 
@@ -159,7 +160,7 @@ jobs:
 
       # Upload QCoW2 as "containerdisk" OCI image as expected by KubeVirt
       - name: Create the Containerfile for building the containerdisk image
-        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format == 'qcow2'
+        if: ${{ matrix.format == 'qcow2' }}
         run: |
           cat <<EOF > Containerfile.qcow2
           FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
@@ -171,12 +172,12 @@ jobs:
           EOF
 
       - name: Build the containerdisk image
-        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format == 'qcow2'
+        if: ${{ matrix.format == 'qcow2' }}
         run: |
           podman build -t ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG} -f Containerfile.qcow2 .
 
       - name: Push the containerdisk image to registry as OCI image and sign it
-        if: steps.check-containerfile.outputs.exists == 'true' && matrix.format == 'qcow2'
+        if: ${{ matrix.format == 'qcow2' }}
         run: |
           printf '%s' '${{ secrets.SIGNING_KEY_PRIVATE }}' > ./signingkey.private
           podman push --sign-by-sigstore-private-key ./signingkey.private ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG}
@@ -184,7 +185,7 @@ jobs:
 
 
   build-bootc-disk-manifestlist:
-    needs: [build-bootc-disk-images]
+    needs: [preflight, build-bootc-disk-images]
 
     strategy:
       matrix:
@@ -237,28 +238,10 @@ jobs:
           echo "OCI_DISK_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}/diskimage-${{ matrix.format }}" >> $GITHUB_ENV
           echo "OCI_DISK_IMAGE_TAG=${GITHUB_SHA::8}" >> $GITHUB_ENV
 
-      - name: Detect available architectures
-        id: detect-archs
-        run: |
-          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
-          ARCHS=""
-          for arch in amd64 arm64; do
-            if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
-              ARCHS="${ARCHS} ${arch}"
-            fi
-          done
-          ARCHS=$(echo "${ARCHS}" | xargs)
-          if [ -z "${ARCHS}" ]; then
-            echo "Error: No Containerfiles found for any architecture"
-            exit 1
-          fi
-          echo "archs=${ARCHS}" >> $GITHUB_OUTPUT
-          echo "Architectures to include in manifest: ${ARCHS}"
-
       - name: Create manifest list
         run: |
           podman manifest create ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG}
-          for arch in ${{ steps.detect-archs.outputs.archs }}; do
+          for arch in ${{ needs.preflight.outputs.archs }}; do
             podman manifest add --all ${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG} docker://${OCI_DISK_IMAGE}:${OCI_DISK_IMAGE_TAG}-${arch}
           done
 

--- a/.github/workflows/build-bootc-image.yaml
+++ b/.github/workflows/build-bootc-image.yaml
@@ -78,7 +78,27 @@ on:
         required: false
 
 jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v4
+
+      - name: Verify at least one Containerfile exists
+        run: |
+          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          for arch in amd64 arm64; do
+            if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
+              echo "Found Containerfile for ${arch}"
+              exit 0
+            fi
+          done
+          echo "Error: No Containerfile found for any architecture in ${DEMO_DIR}/bootc/"
+          exit 1
+
   build-bootc-images:
+    needs: [preflight]
+
     strategy:
       matrix:
         runner: ["ubuntu-24.04","ubuntu-24.04-arm"]
@@ -98,7 +118,19 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
 
+      - name: Check if Containerfile exists for this architecture
+        id: check-containerfile
+        run: |
+          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          if [ -f "${DEMO_DIR}/bootc/Containerfile.${{ env.ARCH }}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "No Containerfile found for ${{ env.ARCH }}, skipping build"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install Podman 5 and configure it to attach Sigstore signatures
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           dnf -y install podman
           tee "/etc/containers/registries.d/${{ inputs.oci-registry }}.yaml" > /dev/null <<EOF
@@ -108,25 +140,25 @@ jobs:
           EOF
 
       - name: Log in to OCI registry
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: podman login -u '${{ secrets.OCI_REGISTRY_USERNAME }}' -p '${{ secrets.OCI_REGISTRY_PASSWORD }}' ${{ inputs.oci-registry }}
 
       - name: Set env vars
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           echo "OCI_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}" >> $GITHUB_ENV
           echo "OCI_IMAGE_TAG=${GITHUB_SHA::8}-${{ env.ARCH }}" >> $GITHUB_ENV
 
       - name: Build bootc image
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
           pushd ${DEMO_DIR}/bootc
-          # Determine which Containerfile to use
+          # Determine which Containerfile to use (existence already verified)
           if [ -f "Containerfile.${{ env.ARCH }}" ]; then
             CONTAINERFILE="Containerfile.${{ env.ARCH }}"
-          elif [ -f "Containerfile" ]; then
-            CONTAINERFILE="Containerfile"
           else
-            echo "Error: No Containerfile found (looked for Containerfile.${{ env.ARCH }} and Containerfile)"
-            exit 1
+            CONTAINERFILE="Containerfile"
           fi
           if [ -n "${AGENT_CONFIG}" ]; then
             echo "${AGENT_CONFIG}" | base64 -d > config.yaml
@@ -140,10 +172,11 @@ jobs:
           popd
 
       - name: Lint bootc image
+        if: steps.check-containerfile.outputs.exists == 'true'
         run: podman run --rm ${OCI_IMAGE}:${OCI_IMAGE_TAG} bootc container lint --fatal-warnings --skip var-tmpfiles
 
       - name: Push image to registry and sign it
-        if: ${{ ! inputs.dry_run }}
+        if: steps.check-containerfile.outputs.exists == 'true' && ! inputs.dry_run
         run: |
           printf '%s' '${{ secrets.SIGNING_KEY_PRIVATE }}' > ./signingkey.private
           podman push --sign-by-sigstore-private-key ./signingkey.private ${OCI_IMAGE}:${OCI_IMAGE_TAG}
@@ -199,10 +232,28 @@ jobs:
           echo "OCI_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}" >> $GITHUB_ENV
           echo "OCI_IMAGE_TAG=${GITHUB_SHA::8}" >> $GITHUB_ENV
 
+      - name: Detect available architectures
+        id: detect-archs
+        run: |
+          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          ARCHS=""
+          for arch in amd64 arm64; do
+            if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
+              ARCHS="${ARCHS} ${arch}"
+            fi
+          done
+          ARCHS=$(echo "${ARCHS}" | xargs)
+          if [ -z "${ARCHS}" ]; then
+            echo "Error: No Containerfiles found for any architecture"
+            exit 1
+          fi
+          echo "archs=${ARCHS}" >> $GITHUB_OUTPUT
+          echo "Architectures to include in manifest: ${ARCHS}"
+
       - name: Create manifest list
         run: |
           podman manifest create ${OCI_IMAGE}:${OCI_IMAGE_TAG}
-          for arch in amd64 arm64; do
+          for arch in ${{ steps.detect-archs.outputs.archs }}; do
             podman manifest add ${OCI_IMAGE}:${OCI_IMAGE_TAG} docker://${OCI_IMAGE}:${OCI_IMAGE_TAG}-${arch}
           done
 

--- a/.github/workflows/build-bootc-image.yaml
+++ b/.github/workflows/build-bootc-image.yaml
@@ -80,28 +80,44 @@ on:
 jobs:
   preflight:
     runs-on: ubuntu-24.04
+    outputs:
+      runners: ${{ steps.detect-archs.outputs.runners }}
+      archs: ${{ steps.detect-archs.outputs.archs }}
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
 
-      - name: Verify at least one Containerfile exists
+      - name: Detect available architectures
+        id: detect-archs
         run: |
           DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
+          RUNNERS="[]"
+          ARCHS=""
           for arch in amd64 arm64; do
             if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
-              echo "Found Containerfile for ${arch}"
-              exit 0
+              if [ "${arch}" = "amd64" ]; then
+                RUNNERS=$(echo "${RUNNERS}" | jq -c '. + ["ubuntu-24.04"]')
+              else
+                RUNNERS=$(echo "${RUNNERS}" | jq -c '. + ["ubuntu-24.04-arm"]')
+              fi
+              ARCHS="${ARCHS} ${arch}"
             fi
           done
-          echo "Error: No Containerfile found for any architecture in ${DEMO_DIR}/bootc/"
-          exit 1
+          ARCHS=$(echo "${ARCHS}" | xargs)
+          if [ -z "${ARCHS}" ]; then
+            echo "Error: No Containerfile found for any architecture in ${DEMO_DIR}/bootc/"
+            exit 1
+          fi
+          echo "runners=${RUNNERS}" >> $GITHUB_OUTPUT
+          echo "archs=${ARCHS}" >> $GITHUB_OUTPUT
+          echo "Architectures: ${ARCHS}, Runners: ${RUNNERS}"
 
   build-bootc-images:
     needs: [preflight]
 
     strategy:
       matrix:
-        runner: ["ubuntu-24.04","ubuntu-24.04-arm"]
+        runner: ${{ fromJSON(needs.preflight.outputs.runners) }}
       fail-fast: false
 
     runs-on: ${{ matrix.runner }}
@@ -118,19 +134,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
 
-      - name: Check if Containerfile exists for this architecture
-        id: check-containerfile
-        run: |
-          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
-          if [ -f "${DEMO_DIR}/bootc/Containerfile.${{ env.ARCH }}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "No Containerfile found for ${{ env.ARCH }}, skipping build"
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Install Podman 5 and configure it to attach Sigstore signatures
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           dnf -y install podman
           tee "/etc/containers/registries.d/${{ inputs.oci-registry }}.yaml" > /dev/null <<EOF
@@ -140,21 +144,18 @@ jobs:
           EOF
 
       - name: Log in to OCI registry
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: podman login -u '${{ secrets.OCI_REGISTRY_USERNAME }}' -p '${{ secrets.OCI_REGISTRY_PASSWORD }}' ${{ inputs.oci-registry }}
 
       - name: Set env vars
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           echo "OCI_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}" >> $GITHUB_ENV
           echo "OCI_IMAGE_TAG=${GITHUB_SHA::8}-${{ env.ARCH }}" >> $GITHUB_ENV
 
       - name: Build bootc image
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: |
           DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
           pushd ${DEMO_DIR}/bootc
-          # Determine which Containerfile to use (existence already verified)
+          # Determine which Containerfile to use (existence verified by preflight)
           if [ -f "Containerfile.${{ env.ARCH }}" ]; then
             CONTAINERFILE="Containerfile.${{ env.ARCH }}"
           else
@@ -172,18 +173,17 @@ jobs:
           popd
 
       - name: Lint bootc image
-        if: steps.check-containerfile.outputs.exists == 'true'
         run: podman run --rm ${OCI_IMAGE}:${OCI_IMAGE_TAG} bootc container lint --fatal-warnings --skip var-tmpfiles
 
       - name: Push image to registry and sign it
-        if: steps.check-containerfile.outputs.exists == 'true' && ! inputs.dry_run
+        if: ${{ ! inputs.dry_run }}
         run: |
           printf '%s' '${{ secrets.SIGNING_KEY_PRIVATE }}' > ./signingkey.private
           podman push --sign-by-sigstore-private-key ./signingkey.private ${OCI_IMAGE}:${OCI_IMAGE_TAG}
 
 
   build-bootc-manifestlist:
-    needs: [build-bootc-images]
+    needs: [preflight, build-bootc-images]
 
     if: ${{ ! inputs.dry_run }}
 
@@ -232,28 +232,10 @@ jobs:
           echo "OCI_IMAGE=${{ inputs.oci-registry }}/${{ inputs.oci-org }}/${{ inputs.demo }}" >> $GITHUB_ENV
           echo "OCI_IMAGE_TAG=${GITHUB_SHA::8}" >> $GITHUB_ENV
 
-      - name: Detect available architectures
-        id: detect-archs
-        run: |
-          DEMO_DIR=$([ -d "base/${{ inputs.demo }}" ] && echo "base/${{ inputs.demo }}" || echo "demos/${{ inputs.demo }}")
-          ARCHS=""
-          for arch in amd64 arm64; do
-            if [ -f "${DEMO_DIR}/bootc/Containerfile.${arch}" ] || [ -f "${DEMO_DIR}/bootc/Containerfile" ]; then
-              ARCHS="${ARCHS} ${arch}"
-            fi
-          done
-          ARCHS=$(echo "${ARCHS}" | xargs)
-          if [ -z "${ARCHS}" ]; then
-            echo "Error: No Containerfiles found for any architecture"
-            exit 1
-          fi
-          echo "archs=${ARCHS}" >> $GITHUB_OUTPUT
-          echo "Architectures to include in manifest: ${ARCHS}"
-
       - name: Create manifest list
         run: |
           podman manifest create ${OCI_IMAGE}:${OCI_IMAGE_TAG}
-          for arch in ${{ steps.detect-archs.outputs.archs }}; do
+          for arch in ${{ needs.preflight.outputs.archs }}; do
             podman manifest add ${OCI_IMAGE}:${OCI_IMAGE_TAG} docker://${OCI_IMAGE}:${OCI_IMAGE_TAG}-${arch}
           done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ The repository uses the following GitHub Actions workflows for building and publ
 
 **What it does:**
 
-- Builds a bootc image for the specified demo for both amd64 and arm64 architectures (`demos/DEMO_NAME/bootc/**`)
+- Builds a bootc image for the specified demo for each available architecture (`demos/DEMO_NAME/bootc/**`)
 - Optionally, adds a specified agent config to the image.
 - If `dry_run` is not specified or is `false`, creates a multi-architecture manifest list.
 - If `dry_run` is not specified or is `false`, signs and publishes the manifest list and images to the specified registry.
@@ -77,8 +77,8 @@ The repository uses the following GitHub Actions workflows for building and publ
 
 **What it does:**
 
-- Pulls the specified bootc image for both amd64 and arm64 architectures.
-- Uses bootc image builder to build `.raw`, `.qcow2`, and `.iso` artifacts for both amd64 and arm64 architectures.
+- Pulls the specified bootc image for each available architecture.
+- Uses bootc image builder to build `.raw`, `.qcow2`, and `.iso` artifacts for each available architecture.
 - Signs and publishes these artifacts to the specified registry.
 
 **Build time:** ~5-10 minutes
@@ -92,7 +92,7 @@ The repository uses the following GitHub Actions workflows for building and publ
 **What it does:**
 
 - Detects which bootc images changed (by looking for changes in `**/bootc/**`)
-- Builds changed bootc images for both amd64 and arm64 architectures
+- Builds changed bootc images for each available architecture (skips architectures with no Containerfile)
 - Runs `bootc container lint --fatal-warnings` on built images
 - **Does NOT** build disk images (too slow for PR validation)
 - **Does NOT** push images to registry
@@ -108,9 +108,9 @@ The repository uses the following GitHub Actions workflows for building and publ
 **What it does:**
 
 - Detects which bootc images changed in the merge
-- Builds changed bootc images for both amd64 and arm64 architectures
+- Builds changed bootc images for each available architecture (skips architectures with no Containerfile)
 - Runs `bootc container lint --fatal-warnings` on built images
-- Builds disk images (ISO, RAW, QCoW2) for all architectures
+- Builds disk images (ISO, RAW, QCoW2) for each available architecture
 - Creates multi-architecture manifest lists
 - Signs all images with Sigstore
 - Publishes to quay.io/flightctl-demos with tags: `latest` and `<commit-sha>`
@@ -225,10 +225,10 @@ oras pull quay.io/flightctl-demos/centos-bootc/diskimage-iso:stream9-20260117143
 
 ### Multi-Architecture Support
 
-- All images support both amd64 and arm64 architectures
+- Images can support both amd64 and arm64 architectures, or a single architecture only
 - Separate Containerfiles per architecture allow arch-specific customization
-- GitHub Actions matrix builds both architectures in parallel
-- Final manifest lists reference both architectures
+- GitHub Actions matrix builds both architectures in parallel; runners with no matching Containerfile skip gracefully
+- Final manifest lists include only the architectures that were actually built
 
 ### Flight Control Integration
 
@@ -247,7 +247,7 @@ oras pull quay.io/flightctl-demos/centos-bootc/diskimage-iso:stream9-20260117143
 
 ## Working with Containerfiles
 
-When modifying Containerfile.amd64 or Containerfile.arm64:
+When modifying Containerfiles (e.g. `Containerfile.amd64`, `Containerfile.arm64`):
 
 1. **Package installation**: Always install minimal and clean up package metadata to reduce image size:
 
@@ -272,7 +272,7 @@ When modifying Containerfile.amd64 or Containerfile.arm64:
 
 4. **Linting**: Including `RUN bootc container lint` as the final step is recommended for early feedback during local builds. However, CI workflows enforce linting automatically, so forgotten lints won't slip through
 
-5. **Keep architecture variants in sync**: Changes to one architecture should typically be mirrored to the other unless there's an architecture-specific reason
+5. **Keep architecture variants in sync**: When both architecture Containerfiles exist, changes to one should typically be mirrored to the other unless there's an architecture-specific reason. Single-architecture demos (only `Containerfile.amd64` or `Containerfile.arm64`) are also supported
 
 ## Flight Control Fleet Definitions
 
@@ -323,7 +323,7 @@ To add a new demo image:
    mkdir -p NEW_DEMO/{bootc,deploy,configuration/etc}
    ```
 
-2. Create `bootc/Containerfile.amd64` and `bootc/Containerfile.arm64`:
+2. Create `bootc/Containerfile.amd64` (and optionally `bootc/Containerfile.arm64` if multi-arch is needed):
 
    - **Demos must use local base images** (they include the flightctl-agent):
      - CentOS-based: `FROM quay.io/flightctl-demos/centos-bootc:latest`
@@ -332,6 +332,7 @@ To add a new demo image:
    - Add configuration files with `ADD` statements
    - Enable systemd services
    - Run `bootc container lint`
+   - Only architectures with a matching Containerfile will be built; the manifest list includes only those
 
 3. Create `bootc/Containerfile.tags` with initial tags:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a preflight check to detect which architecture-specific build definitions exist and fail early if none are found.
  * Build jobs now run only for detected architectures and skip gated setup/push/sign steps when an architecture is absent.
  * Manifest-list creation now includes only architectures actually built, not a fixed set.

* **Documentation**
  * Updated docs to describe conditional single/multi-architecture builds and guidance for adding demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->