### PR TITLE
Update CodeRabbit config: refine action pinning, enforce AI attribution

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -225,7 +225,10 @@ reviews:
         GitHub Actions workflow review — security AND design:
 
         Security:
-        - Pin actions by full commit SHA, not floating tag
+        - GitHub-owned actions (actions/*) use tag refs (e.g., @v4)
+          for readability — do NOT flag these for missing SHA pins.
+          Third-party actions must be pinned by full SHA with a
+          trailing version comment (e.g., @<sha> # v1.2.3).
         - No secrets in logs; mask sensitive outputs
         - Least privilege: minimize GITHUB_TOKEN permissions; declare
           explicit permissions block
@@ -446,9 +449,10 @@ reviews:
       - name: "ai-attribution"
         instructions: |
           If AI tools were used (mentioned in PR or commits), verify
-          Red Hat attribution: Assisted-by or Generated-by trailers.
+          attribution trailers: Assisted-by, Generated-by, or
+          Made-with (e.g., Made-with: Cursor) are acceptable.
           Flag use of Co-Authored-By for AI tools.
-        mode: "warning"
+        mode: "error"
 
 # ── Knowledge base ───────────────────────────────────────────
 knowledge_base:


### PR DESCRIPTION
## Summary

- Refine action-pinning rule: allow tag refs for GitHub-owned actions (`actions/*`), require SHA pins only for third-party actions
- Update `ai-attribution` check: accept `Made-with` trailers (e.g., `Made-with: Cursor`) alongside `Assisted-by` and `Generated-by`
- Escalate `ai-attribution` from warning to error

## Test plan

- [ ] Verify CodeRabbit does not flag `actions/checkout@v4` or similar GitHub-owned action tag refs
- [ ] Verify `ai-attribution` fires at error severity on PRs with `Co-Authored-By` AI trailers

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Files affected:**
- `.coderabbit.yaml` (new configuration file)

**Areas impacted:**
- **CI/CD pipelines** (code review automation configuration only)

**What changed:**

This PR introduces the complete CodeRabbit code review configuration for the flightctl-demos repository. The configuration is a new, comprehensive set of instructions and automation rules, not modifications to an existing file.

Key elements of the configuration include:
1. **GitHub Actions security guidance** — Refined action pinning rules that explicitly permit tag refs (e.g., `@v4`) for GitHub-owned actions under `actions/*` namespace, while requiring full-SHA pins with trailing version comments for third-party actions.
2. **AI attribution enforcement** — Updated `ai-attribution` pre-merge check that accepts `Assisted-by`, `Generated-by`, or `Made-with` (e.g., `Made-with: Cursor`) trailers as valid attribution, flags `Co-Authored-By` for AI tools, and escalates severity from warning to error.
3. **Path-specific review instructions** — Comprehensive guidance for reviewing bootc Containerfiles (base and demo images), demo application images, Fleet manifests, Kubernetes/OpenShift manifests, Quadlet units, workflows, composite actions, and application code (Python, JavaScript, shell, HTML, CSS).
4. **Security scanning tools** — Enables gitleaks, semgrep, checkov, hadolint, actionlint, yamllint, markdownlint, and ast-grep.

**No runtime or build artifacts affected** — this is a configuration-only change to code review automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->